### PR TITLE
Fixes for highlighting, chat, blank slay reason

### DIFF
--- a/lua/damagelogs/client/tabs/rdm_manager.lua
+++ b/lua/damagelogs/client/tabs/rdm_manager.lua
@@ -1021,7 +1021,7 @@ function PANEL:Init()
     self.CustomReason = vgui.Create("DTextEntry", self)
     self.CustomReason:SetPos(self.Distance / 2 + self.Dimension / 2 + 25, self.Dimension * 2 / 3)
     self.CustomReason:SetSize(self.Dimension * 1.5 - 35, 25)
-    self.CustomReason:SetText(TTTLogTranslate(GetDMGLogLang, "DefaultReason"))
+    self.CustomReason:SetText("")
 
     self.CustomReason.OnChange = function(panel)
         self:UpdateReason()

--- a/lua/damagelogs/config/config.lua
+++ b/lua/damagelogs/config/config.lua
@@ -53,6 +53,7 @@ Damagelog.ULX_AutoslayMode = 1
 -- Do not enable this if another addon interferes with roles (Pointshop roles for example)
 Damagelog.ULX_Autoslay_ForceRole = true
 -- Default autoslay reasons (ULX and ServerGuard)
+Damagelog.Autoslay_DefaultReason = "broke server rules"
 Damagelog.Autoslay_DefaultReason1 = "random kill"
 Damagelog.Autoslay_DefaultReason2 = "multiple random kills"
 Damagelog.Autoslay_DefaultReason3 = "random damage"

--- a/lua/damagelogs/server/chat.lua
+++ b/lua/damagelogs/server/chat.lua
@@ -301,9 +301,8 @@ end)
 
 net.Receive("DL_CloseChat", function(_len, ply)
     local id = net.ReadUInt(32)
-    local to_add = net.ReadEntity()
 
-    if not ply:CanUseRDMManager() or not IsValid(to_add) or not to_add:IsPlayer() then
+    if not ply:CanUseRDMManager() then
         return
     end
 

--- a/lua/damagelogs/shared/events.lua
+++ b/lua/damagelogs/shared/events.lua
@@ -76,37 +76,17 @@ function Damagelog:InfoFromID(tbl, id)
     }
 end
 
-function Damagelog:IsTeamkill(attacker, victim)
-    if not IsValid(attacker) or not IsValid(victim) then
-        return false
-    end
-
-    local role1 = attacker:GetRole()
-    local role2 = victim:GetRole()
-
-    if not ROLES then
-        if role1 == role2 then
-            return true
-        elseif role1 == ROLE_DETECTIVE and role2 == ROLE_INNOCENT then
-            return true
-        elseif role1 == ROLE_INNOCENT and role2 == ROLE_DETECTIVE then
-            return true
-        end
-    else
-        local rda = attacker:GetRoleData()
-        local rdv = victim:GetRoleData()
-        local rdaTeam = hook.Run("TTT2_ModifyRole", attacker) or rda
-        rdaTeam = rdaTeam.team
-        local rdvTeam = hook.Run("TTT2_ModifyRole", victim) or rdv
-        rdvTeam = rdvTeam.team
-
-        if rdaTeam and rdaTeam == rdvTeam and (not rdv.unknownTeam or rdaTeam == TEAM_TRAITOR) then
-            return true
-        end
-    end
-
-    return false
+function Damagelog:IsTeamkill(role1, role2)
+	if role1 == role2 then 
+		return true
+	elseif role1 == ROLE_DETECTIVE and role2 == ROLE_INNOCENT then 
+		return true
+	elseif role1 == ROLE_INNOCENT and role2 == ROLE_DETECTIVE then 
+		return true
+	end
+	return false
 end
+
 
 local function includeEventFile(f)
     f = "damagelogs/shared/events/" .. f

--- a/lua/damagelogs/shared/events/damages.lua
+++ b/lua/damagelogs/shared/events/damages.lua
@@ -38,7 +38,7 @@ function event:PlayerTakeRealDamage(ent, dmginfo, original_dmg)
                 [5] = math.Round(original_dmg)
             }
 
-            if Damagelog:IsTeamkill(att, ent) then
+            if Damagelog:IsTeamkill(att.role, ent.role) then
                 tbl.icon = {"icon16/exclamation.png"}
             elseif Damagelog.Time then
                 local found_dmg = false
@@ -114,7 +114,7 @@ function event:GetColor(tbl, roles)
     local ent = Damagelog:InfoFromID(roles, tbl[1])
     local att = Damagelog:InfoFromID(roles, tbl[2])
 
-    if Damagelog:IsTeamkill(player.GetBySteamID64(att.steamid64), player.GetBySteamID64(ent.steamid64)) then
+    if Damagelog:IsTeamkill(att.role, ent.role) then
         return Damagelog:GetColor("color_team_damages")
     else
         return Damagelog:GetColor("color_damages")

--- a/lua/damagelogs/shared/events/kills.lua
+++ b/lua/damagelogs/shared/events/kills.lua
@@ -72,7 +72,7 @@ function event:GetColor(tbl, roles)
     local ent = Damagelog:InfoFromID(roles, tbl[1])
     local att = Damagelog:InfoFromID(roles, tbl[2])
 
-    if Damagelog:IsTeamkill(player.GetBySteamID64(att.steamid64), player.GetBySteamID64(ent.steamid64)) then
+    if Damagelog:IsTeamkill(att.role, ent.role) then
         return Damagelog:GetColor("color_team_kills")
     else
         return Damagelog:GetColor("color_kills")


### PR DESCRIPTION
https://github.com/Tommy228/tttdamagelogs/issues/390

1. ✔ Some rows appear red for teamkilling, despite the kill not being a teamkill ([thanks RockonBen](https://github.com/Tommy228/tttdamagelogs/issues/390#issuecomment-554649603))
2. ~~Can't respond to multiple reports~~
3. ✔ Admin chat can't be closed ([thanks RockonBen](https://github.com/Tommy228/tttdamagelogs/issues/390#issuecomment-554643227))
4. ✔ Default aslay reason not set (commit c9c38ba and [thanks RockonBen](https://github.com/Tommy228/tttdamagelogs/issues/390#issuecomment-554643846))

I have not tested if these actually fix the issues.