### PR TITLE
Fix issue with autoslay SQL

### DIFF
--- a/lua/damagelogs/shared/autoslay.lua
+++ b/lua/damagelogs/shared/autoslay.lua
@@ -33,7 +33,7 @@ local function CreateCommand()
 
     function ulx.cslays(calling_ply, target)
         -- TODO: Support MySQL
-        local data = Damagelog.SQLiteDatabase.QuerySingle("SELECT * FROM damagelog_autoslay WHERE ply = '" .. target:SteamID() .. "' LIMIT 1")
+        local data = Damagelog.SQLiteDatabase.QuerySingle(string.format("SELECT * FROM damagelog_autoslay WHERE ply = %s", sql.SQLStr(target:SteamID())))
         local txt = aslay and "slays" or "jails"
         local p = "has"
 
@@ -56,7 +56,7 @@ local function CreateCommand()
         end
 
         -- TODO: Support MySQL
-        local data = Damagelog.SQLiteDatabase.QuerySingle("SELECT * FROM damagelog_autoslay WHERE ply = '" .. steamid .. "' LIMIT 1")
+        local data = Damagelog.SQLiteDatabase.QuerySingle(string.format("SELECT * FROM damagelog_autoslay WHERE ply = %s", sql.SQLStr(target:SteamID())))
         local txt = aslay and "slays" or "jails"
 
         if data then


### PR DESCRIPTION
Fixes #16 

This fixes an issue where LIMIT was being used in an unsupported way in UPDATE queries.

It also removes a few redundant usages of the LIMIT keyword and ensures that some queries are properly escaping string parameters.


