### PR TITLE
Prevents players from submitting reports with a message that is too long

### DIFF
--- a/lua/damagelogs/server/rdm_manager.lua
+++ b/lua/damagelogs/server/rdm_manager.lua
@@ -516,10 +516,15 @@ function HandlePlayerReport(ply, attacker, message, reportType)
     UpdatePreviousReports()
 end
 net.Receive("DL_ReportPlayer", function(len, ply)
-    local attacker = net.ReadEntity()
-    local message = net.ReadString()
-    local reportType = net.ReadUInt(3)
-    HandlePlayerReport(ply, attacker, message, reportType)
+    local length = net.ReadUInt(32)
+    local requestPayload = net.ReadData(length)
+    local request = util.JSONToTable(util.Decompress(requestPayload))
+
+    local target = request.target
+    local message = string.sub(request.message, 0, 1000)
+    local reportType = request.reportType
+
+    HandlePlayerReport(ply, target, message, reportType)
 end)
 
 

--- a/lua/damagelogs/shared/lang/english.lua
+++ b/lua/damagelogs/shared/lang/english.lua
@@ -104,6 +104,7 @@ DamagelogLang.english = {
     Submit = "Submit",
     SubmitEvenWithNoStaff = "Submit, even if there's no staff online",
     NotEnoughCharacters = "Not enough characters to submit",
+    TooManyCharacters = "Your message is too long",
     LogsBeforeDeath = "Logs before your death",
     MessageFrom = "message from",
     AboutYourReport = "about your report.",


### PR DESCRIPTION
Fixes #27 

Limits a report message to 1000 characters max.