### PR TITLE
Add a hook 'RDMManagerStatusUpdated', called when report status is updated.

### DIFF
--- a/lua/damagelogs/server/rdm_manager.lua
+++ b/lua/damagelogs/server/rdm_manager.lua
@@ -516,6 +516,8 @@ net.Receive("DL_UpdateStatus", function(_len, ply)
     tbl.status = status
     tbl.admin = status == RDM_MANAGER_WAITING and false or ply:Nick()
     local msg
+        
+    hook.Run("RDMManagerStatusUpdated", ply, index, status, previous)
 
     if status == RDM_MANAGER_WAITING then
         msg = string_format(TTTLogTranslate(ply.DMGLogLang, "HasSetReport"), ply:Nick(), index, TTTLogTranslate(ply.DMGLogLang, "RDMWaiting"))


### PR DESCRIPTION
Adding this can make it easier for people to add custom staff tracking without the need to modify the addon to track staff finishing reports etc.

```lua
hook.Add("RDMManagerStatusUpdated", "Example", function(
	ply, -- The player who updated the report status,
	index, -- The report index, can be used to track unique reports so staff can't keep setting to finished to add to activity
	status, -- The new report status
	previous -- The previous report status
)
-- Custom code to update database etc...
end)