### PR TITLE
Add two new configs settings, Check Custom by default and Allow banning fromRDMManager

### DIFF
--- a/lua/damagelogs/client/tabs/rdm_manager.lua
+++ b/lua/damagelogs/client/tabs/rdm_manager.lua
@@ -228,25 +228,27 @@ local function TakeAction()
                 frame:SetPlayer(false, victim, report.victim, report)
             end):SetImage("icon16/user.png")
 
-            slaynr_pnl2 = vgui.Create("DMenuOption", menuPanel)
-            slaynr2 = DermaMenu(menuPanel)
-            slaynr2:SetVisible(false)
-            slaynr_pnl2:SetSubMenu(slaynr2)
-            slaynr_pnl2:SetText("Ban")
-            slaynr_pnl2:SetImage("icon16/bomb.png")
-            menuPanel:AddPanel(slaynr_pnl2)
+            if Damagelog.AllowBanningThruManager then
+                slaynr_pnl2 = vgui.Create("DMenuOption", menuPanel)
+                slaynr2 = DermaMenu(menuPanel)
+                slaynr2:SetVisible(false)
+                slaynr_pnl2:SetSubMenu(slaynr2)
+                slaynr_pnl2:SetText("Ban")
+                slaynr_pnl2:SetImage("icon16/bomb.png")
+                menuPanel:AddPanel(slaynr_pnl2)
 
-            slaynr2:AddOption(TTTLogTranslate(GetDMGLogLang, "ReportedPlayer") .. " (" .. report.attacker_nick .. ")", function()
-                local frame = vgui.Create("RDM_Manager_Ban_Reason", Damagelog.Menu)
-                frame.SetConclusion = SetConclusionBan
-                frame:SetPlayer(true, attacker, report.attacker, report)
-            end):SetImage("icon16/user_delete.png")
+                slaynr2:AddOption(TTTLogTranslate(GetDMGLogLang, "ReportedPlayer") .. " (" .. report.attacker_nick .. ")", function()
+                    local frame = vgui.Create("RDM_Manager_Ban_Reason", Damagelog.Menu)
+                    frame.SetConclusion = SetConclusionBan
+                    frame:SetPlayer(true, attacker, report.attacker, report)
+                end):SetImage("icon16/user_delete.png")
 
-            slaynr2:AddOption(TTTLogTranslate(GetDMGLogLang, "Victim") .. " (" .. report.victim_nick .. ")", function()
-                local frame = vgui.Create("RDM_Manager_Ban_Reason", Damagelog.Menu)
-                frame.SetConclusion = SetConclusionBan
-                frame:SetPlayer(false, victim, report.victim, report)
-            end):SetImage("icon16/user.png")
+                slaynr2:AddOption(TTTLogTranslate(GetDMGLogLang, "Victim") .. " (" .. report.victim_nick .. ")", function()
+                    local frame = vgui.Create("RDM_Manager_Ban_Reason", Damagelog.Menu)
+                    frame.SetConclusion = SetConclusionBan
+                    frame:SetPlayer(false, victim, report.victim, report)
+                end):SetImage("icon16/user.png")
+            end
         end
 
         menuPanel:AddOption(TTTLogTranslate(GetDMGLogLang, "SlayReportedPlayerNow"), function()
@@ -1018,7 +1020,11 @@ function PANEL:Init()
     self.Reason:SetText(TTTLogTranslate(GetDMGLogLang, "Reason"))
     self.CREnable = vgui.Create("DCheckBox", self)
     self.CREnable:SetPos(self.Distance / 2 + self.Dimension / 2, self.Dimension * 2 / 3 + 5)
-    self.CREnable:SetValue(0)
+    if Damagelog.Autoslay_CheckCustom then
+        self.CREnable:SetValue(1)
+    else
+        self.CREnable:SetValue(0)
+    end    
 
     function self.CREnable.OnChange(panel, reasonTxt)
         self:UpdateReason()

--- a/lua/damagelogs/config/config.lua
+++ b/lua/damagelogs/config/config.lua
@@ -53,6 +53,8 @@ Damagelog.ULX_AutoslayMode = 1
 -- Force autoslain players to be innocents (ULX/SAM only)
 -- Do not enable this if another addon interferes with roles (Pointshop roles for example)
 Damagelog.ULX_Autoslay_ForceRole = true
+--Auto check Custom slay Reason
+Damagelog.Autoslay_CheckCustom = false
 -- Default autoslay reasons (ULX, SAM, and ServerGuard)
 Damagelog.Autoslay_DefaultReason = "Breaking Rules"
 Damagelog.Autoslay_DefaultReason1 = "Random Damage"
@@ -97,7 +99,8 @@ Damagelog.MoreReportsPerRound = false
 Damagelog.ReportsBeforePlaying = false
 -- Private message prefix from RDM Manager
 Damagelog.PrivateMessagePrefix = "[RDM Manager]"
-
+-- Allow banning thru the RDMManager
+Damagelog.AllowBanningThruManager = true
 
 
 -- Discord Webhooks


### PR DESCRIPTION
The first new config settings is because we updated our copy of tttdamagelogs that use to default to having the Custom Reason box checked by default and found we had to edit the lua to make it checked after updating. (It was driving our staff nuts having to remember to check it.)

I have that setting defaulting to false so that it follows what is already set up in the addon currently.

I have also added a new setting to remove the ban option from the Actions menu, since we have had a few people accidentally ban people when they were trying to issue a slay.  This is defaulted to true so that the functionality of the addon is not change unless you change the config.