### PR TITLE
Fixes #50

### DIFF
--- a/lua/damagelogs/server/oldlogs.lua
+++ b/lua/damagelogs/server/oldlogs.lua
@@ -234,7 +234,7 @@ net.Receive("DL_AskOldLogRounds", function(_, ply)
     local _date = "20" .. year .. "-" .. month .. "-" .. day -- TODO: not the best way if someone uses this in 2100 too ;)
 
     if Damagelog.Use_MySQL and Damagelog.MySQL_Connected then
-        local query_str = "SELECT date,map,round FROM damagelog_oldlogs_v3 WHERE year = ".. year .. "AND month = " .. month .. "AND day = " .. day .." ORDER BY date ASC;"
+        local query_str = "SELECT date,map,round FROM damagelog_oldlogs_v3 WHERE year = ".. year .. " AND month = " .. month .. " AND day = " .. day .." ORDER BY date ASC;"
         local query = Damagelog.database:query(query_str)
 
         query.onSuccess = function(self)
@@ -252,7 +252,7 @@ net.Receive("DL_AskOldLogRounds", function(_, ply)
 
         query:start()
     else
-        local query_str = "SELECT date,map,round FROM damagelog_oldlogs_v3 WHERE  year = ".. year .. "AND month = " .. month .. "AND day = " .. day .."  ORDER BY date ASC;"
+        local query_str = "SELECT date,map,round FROM damagelog_oldlogs_v3 WHERE  year = ".. year .. " AND month = " .. month .. " AND day = " .. day .."  ORDER BY date ASC;"
         local result = Damagelog.SQLiteDatabase.Query(query_str)
 
         if not result then

--- a/lua/damagelogs/server/oldlogs.lua
+++ b/lua/damagelogs/server/oldlogs.lua
@@ -234,7 +234,7 @@ net.Receive("DL_AskOldLogRounds", function(_, ply)
     local _date = "20" .. year .. "-" .. month .. "-" .. day -- TODO: not the best way if someone uses this in 2100 too ;)
 
     if Damagelog.Use_MySQL and Damagelog.MySQL_Connected then
-        local query_str = "SELECT date,map,round FROM damagelog_oldlogs_v3 WHERE date BETWEEN UNIX_TIMESTAMP(\"" .. _date .. " 00:00:00\") AND UNIX_TIMESTAMP(\"" .. _date .. " 23:59:59\") ORDER BY date ASC;"
+        local query_str = "SELECT date,map,round FROM damagelog_oldlogs_v3 WHERE year = ".. year .. "AND month = " .. month .. "AND day = " .. day .." ORDER BY date ASC;"
         local query = Damagelog.database:query(query_str)
 
         query.onSuccess = function(self)
@@ -252,7 +252,7 @@ net.Receive("DL_AskOldLogRounds", function(_, ply)
 
         query:start()
     else
-        local query_str = "SELECT date,map,round FROM damagelog_oldlogs_v3 WHERE date BETWEEN strftime(\"%s\", \"" .. _date .. " 00:00:00\") AND strftime(\"%s\", \"" .. _date .. " 23:59:59\") ORDER BY date ASC;"
+        local query_str = "SELECT date,map,round FROM damagelog_oldlogs_v3 WHERE  year = ".. year .. "AND month = " .. month .. "AND day = " .. day .."  ORDER BY date ASC;"
         local result = Damagelog.SQLiteDatabase.Query(query_str)
 
         if not result then


### PR DESCRIPTION
This fixes #50 while I have only tested this using the built in sqlite database. (sv.db) I am pretty sure it should work properly with external mysql databases as well. 

Also as a suggestion that will also make the logs a bit easier to read.
https://github.com/BadgerCode/tttdamagelogs/blob/master/lua/damagelogs/client/tabs/old_logs.lua#L234

Could we change the `%I` to `%H` so the time matches the on in the title bar above the list. Right now each entry in the list shows up using 12-hour time with no AM or PM. While the little title bar for that hour uses 24-hour time. 