### PR TITLE
WIP: Move config and the MySql config into the data folder as json files.

### DIFF
--- a/lua/damagelogs/config/config.lua
+++ b/lua/damagelogs/config/config.lua
@@ -13,12 +13,13 @@
 	Third argument: access to RDM Manager tab in Damagelogs (true/false).
 ]]
 --
+Damagelog:AddUser("superadmin", 4, true)
 Damagelog:AddUser("owner", 4, true)
 Damagelog:AddUser("founder", 4, true)
-Damagelog:AddUser("superadmin", 4, true)
 Damagelog:AddUser("admin", 4, true)
 Damagelog:AddUser("operator", 3, false)
 Damagelog:AddUser("user", 2, false)
+
 
 -- The F-key
 Damagelog.Key = KEY_F8
@@ -123,3 +124,4 @@ Damagelog.DiscordWebhookMode = 0
 -- Should all players get notified about the amount of remaining slays of a slain player?
 
 Damagelog.ShowRemainingSlays = false
+

--- a/lua/damagelogs/config/config_loader.lua
+++ b/lua/damagelogs/config/config_loader.lua
@@ -3,8 +3,8 @@ function Damagelog:saveConfig()
     local config = {}
     --Permissions
     config.Permissions = {}
-    for user,right in pairs(self.User_rights) do    
-        config.Permissions[user] = {right,self.RDM_Manager_Rights[user]}
+    for user,right in pairs(Damagelog.User_rights) do    
+        config.Permissions[user] = {right,Damagelog.RDM_Manager_Rights[user]}
     end
     config.Key = Damagelog.Key
     config.AbuseMessageMode = Damagelog.AbuseMessageMode
@@ -36,18 +36,18 @@ function Damagelog:saveConfig()
     config.Autoslay.DefaultReason12 = Damagelog.Autoslay_DefaultReason12
     --Ban Stuff
     config.Ban = {}
-    config.Ban.DefaultReason1 = Ban_DefaultReason1
-    config.Ban.DefaultReason2 = Ban_DefaultReason2
-    config.Ban.DefaultReason3 = Ban_DefaultReason3
-    config.Ban.DefaultReason4 = Ban_DefaultReason4
-    config.Ban.DefaultReason5 = Ban_DefaultReason5
-    config.Ban.DefaultReason6 = Ban_DefaultReason6
-    config.Ban.DefaultReason7 = Ban_DefaultReason7
-    config.Ban.DefaultReason8 = Ban_DefaultReason8
-    config.Ban.DefaultReason9 = Ban_DefaultReason9
-    config.Ban.DefaultReason10 = Ban_DefaultReason10
-    config.Ban.DefaultReason11 = Ban_DefaultReason11
-    config.Ban.DefaultReason12 = Ban_DefaultReason12
+    config.Ban.DefaultReason1 = Damagelog.Ban_DefaultReason1
+    config.Ban.DefaultReason2 = Damagelog.Ban_DefaultReason2
+    config.Ban.DefaultReason3 = Damagelog.Ban_DefaultReason3
+    config.Ban.DefaultReason4 = Damagelog.Ban_DefaultReason4
+    config.Ban.DefaultReason5 = Damagelog.Ban_DefaultReason5
+    config.Ban.DefaultReason6 = Damagelog.Ban_DefaultReason6
+    config.Ban.DefaultReason7 = Damagelog.Ban_DefaultReason7
+    config.Ban.DefaultReason8 = Damagelog.Ban_DefaultReason8
+    config.Ban.DefaultReason9 = Damagelog.Ban_DefaultReason9
+    config.Ban.DefaultReason10 = Damagelog.Ban_DefaultReason10
+    config.Ban.DefaultReason11 = Damagelog.Ban_DefaultReason11
+    config.Ban.DefaultReason12 = Damagelog.Ban_DefaultReason12
     config.Ban.AllowBanningThruManager = Damagelog.AllowBanningThruManager
     
     config.LogDays = Damagelog.LogDays
@@ -88,189 +88,189 @@ function Damagelog:loadConfig() --Returns 0 on good load, returns -1 on failure 
         end
     else missing = 1 end
 
-    if not config.Key == nil then
+    if config.Key != nil then
         Damagelog.Key = config.Key
     else missing = 1 end
 
-    if not config.AbuseMessageMode == nil then
+    if config.AbuseMessageMode != nil then
         Damagelog.AbuseMessageMode = config.AbuseMessageMode
     else missing = 1 end
 
-    if not config.RDM_Manager_Enabled == nil then
+    if config.RDM_Manager_Enabled != nil then
         Damagelog.RDM_Manager_Enabled = config.RDM_Manager_Enabled
     else missing = 1 end
 
     if config.Commands then 
-        if not config.Commands.RDM_Manager_Command == nil then
+        if config.Commands.RDM_Manager_Command != nil then
             Damagelog.RDM_Manager_Command = config.Commands.RDM_Manager_Command
         else missing = 1 end
 
-        if not config.Commands.Respond_Command == nil then
+        if config.Commands.Respond_Command != nil then
             Damagelog.Respond_Command = config.Commands.Respond_Command
         else missing = 1 end
     else missing = 1 end
     
-    if not config.Use_MySQL == nil then
+    if config.Use_MySQL != nil then
         Damagelog.Use_MySQL = Damagelog.Use_MySQL
     else missing = 1 end
     
     if config.Autoslay then
-        if not config.Autoslay.ShowRemainingSlays == nil then
+        if config.Autoslay.ShowRemainingSlays != nil then
             Damagelog.ShowRemainingSlays = config.Autoslay.ShowRemainingSlays
         else missing = 1 end
 
-        if not config.Autoslay.ULX_AutoslayMode == nil then
+        if config.Autoslay.ULX_AutoslayMode != nil then
             Damagelog.ULX_AutoslayMode = config.Autoslay.ULX_AutoslayMode
         else missing = 1 end
 
-        if not config.Autoslay.ULX_Autoslay_ForceRole == nil then
-            Damagelog.ULX_Autoslay_ForceRole = config.Autoslau.ULX_Autoslay_ForceRole
+        if config.Autoslay.ULX_Autoslay_ForceRole != nil then
+            Damagelog.ULX_Autoslay_ForceRole = config.Autoslay.ULX_Autoslay_ForceRole
         else missing = 1 end
        
-        if not config.Autoslay.Autoslay_CheckCustom == nil then
+        if config.Autoslay.Autoslay_CheckCustom != nil then
             Damagelog.ULX_Autoslay_ForceRole = config.Autoslay.Autoslay_CheckCustom
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason == nil then
+        if config.Autoslay.DefaultReason != nil then
             Damagelog.Autoslay_DefaultReason = config.Autoslay.DefaultReason
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason1 == nil then
+        if config.Autoslay.DefaultReason1 != nil then
             Damagelog.Autoslay_DefaultReason1 = config.Autoslay.DefaultReason1
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason2 == nil then
+        if config.Autoslay.DefaultReason2 != nil then
             Damagelog.Autoslay_DefaultReason2 = config.Autoslay.DefaultReason2
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason3 == nil then
+        if config.Autoslay.DefaultReason3 != nil then
             Damagelog.Autoslay_DefaultReason3 = config.Autoslay.DefaultReason3
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason4 == nil then
+        if config.Autoslay.DefaultReason4 != nil then
             Damagelog.Autoslay_DefaultReason4 = config.Autoslay.DefaultReason4
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason5 == nil then
+        if config.Autoslay.DefaultReason5 != nil then
             Damagelog.Autoslay_DefaultReason5 = config.Autoslay.DefaultReason5
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason6 == nil then
+        if config.Autoslay.DefaultReason6 != nil then
             Damagelog.Autoslay_DefaultReason6 = config.Autoslay.DefaultReason6
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason7 == nil then
+        if config.Autoslay.DefaultReason7 != nil then
             Damagelog.Autoslay_DefaultReason7 = config.Autoslay.DefaultReason7
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason8 == nil then
+        if config.Autoslay.DefaultReason8 != nil then
             Damagelog.Autoslay_DefaultReason8 = config.Autoslay.DefaultReason8
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason9 == nil then
+        if config.Autoslay.DefaultReason9 != nil then
             Damagelog.Autoslay_DefaultReason9 = config.Autoslay.DefaultReason9
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason10 == nil then
+        if config.Autoslay.DefaultReason10 != nil then
             Damagelog.Autoslay_DefaultReason10 = config.Autoslay.DefaultReason10
         else missing = 1 end
 
-        if not config.Autoslay.DefaultReason11 == nil then
+        if config.Autoslay.DefaultReason11 != nil then
             Damagelog.Autoslay_DefaultReason11 = config.Autoslay.DefaultReason11
         else missing = 1 end
         
-        if not config.Autoslay.DefaultReason12 == nil then
+        if config.Autoslay.DefaultReason12 != nil then
             Damagelog.Autoslay_DefaultReason12 = config.Autoslay.DefaultReason12
         else missing = 1 end
     else missing = 1 end
    
     if config.Ban then
-        if not config.Ban.AllowBanningThruManager == nil then
+        if config.Ban.AllowBanningThruManager != nil then
             Damagelog.AllowBanningThruManager = config.Ban.AllowBanningThruManager
         else missing = 1 end
-
-        if not config.Ban.DefaultReason1 == nil then
+        print(config.Ban.DefaultReason1)
+        if config.Ban.DefaultReason1 != nil then
             Damagelog.Ban_DefaultReason1 = config.Ban.DefaultReason1
         else missing = 1 end
 
-        if not config.Ban.DefaultReason2 == nil then
+        if config.Ban.DefaultReason2 != nil then
             Damagelog.Ban_DefaultReason2 = config.Ban.DefaultReason2
         else missing = 1 end
 
-        if not config.Ban.DefaultReason3 == nil then
+        if config.Ban.DefaultReason3 != nil then
             Damagelog.Ban_DefaultReason3 = config.Ban.DefaultReason3
         else missing = 1 end
 
-        if not config.Ban.DefaultReason4 == nil then
+        if config.Ban.DefaultReason4 != nil then
             Damagelog.Ban_DefaultReason4 = config.Ban.DefaultReason4
         else missing = 1 end
 
-        if not config.Ban.DefaultReason5 == nil then
+        if config.Ban.DefaultReason5 != nil then
             Damagelog.Ban_DefaultReason5 = config.Ban.DefaultReason5
         else missing = 1 end
 
-        if not config.Ban.DefaultReason6 == nil then
+        if config.Ban.DefaultReason6 != nil then
             Damagelog.Ban_DefaultReason6 = config.Ban.DefaultReason6
         else missing = 1 end
 
-        if not config.Ban.DefaultReason7 == nil then
+        if config.Ban.DefaultReason7 != nil then
             Damagelog.Ban_DefaultReason7 = config.Ban.DefaultReason7
         else missing = 1 end
 
-        if not config.Ban.DefaultReason8 == nil then
+        if config.Ban.DefaultReason8 != nil then
             Damagelog.Ban_DefaultReason8 = config.Ban.DefaultReason8
         else missing = 1 end
 
-        if not config.Ban.DefaultReason9 == nil then
+        if config.Ban.DefaultReason9 != nil then
             Damagelog.Ban_DefaultReason9 = config.Ban.DefaultReason9
         else missing = 1 end
 
-        if not config.Ban.DefaultReason10 == nil then
+        if config.Ban.DefaultReason10 != nil then
             Damagelog.Ban_DefaultReason10 = config.Ban.DefaultReason10
         else missing = 1 end
 
-        if not config.Ban.DefaultReason11 == nil then
+        if config.Ban.DefaultReason11 != nil then
             Damagelog.Ban_DefaultReason11 = config.Ban.DefaultReason11
         else missing = 1 end
         
-        if not config.Ban.DefaultReason12 == nil then
+        if config.Ban.DefaultReason12 != nil then
             Damagelog.Ban_DefaultReason12 = config.Ban.DefaultReason12
         else missing = 1 end
     else missing = 1 end
     
     if config.Reports then  
-        if not config.Reports.NoStaffReports == nil then
+        if config.Reports.NoStaffReports != nil then
             Damagelog.NoStaffReports = config.Reports.NoStaffReports
         else missing = 1 end
-        if not config.Reports.MoreReportsPerRound == nil then
+        if config.Reports.MoreReportsPerRound != nil then
             Damagelog.MoreReportsPerRound = config.Reports.MoreReportsPerRound
         else missing = 1 end
-        if not config.Reports.ReportsBeforePlaying == nil then
+        if config.Reports.ReportsBeforePlaying != nil then
             Damagelog.ReportsBeforePlaying = config.Reports.ReportsBeforePlaying
         else missing = 1 end
     else missing = 1 end    
 
-    if not config.LogDays == nil then
+    if config.LogDays != nil then
         Damagelog.LogDays = config.LogDays
     else missing = 1 end
 
-    if not config.HideDonateButton == nil then
+    if config.HideDonateButton != nil then
         Damagelog.HideDonateButton = config.HideDonateButton
     else missing = 1 end
 
-    if not config.UseWorkshop == nil then
+    if config.UseWorkshop != nil then
         Damagelog.UseWorkshop = config.UseWorkshop
     else missing = 1 end
 
-    if not config.ForcedLanguage == nil then
+    if config.ForcedLanguage != nil then
         Damagelog.ForcedLanguage = config.ForcedLanguage
     else missing = 1 end
 
-    if not config.PrivateMessagePrefix == nil then
+    if config.PrivateMessagePrefix != nil then
         Damagelog.PrivateMessagePrefix = config.PrivateMessagePrefix
     else missing = 1 end
 
-    if not config.DiscordWebhookMode == nil then
+    if config.DiscordWebhookMode != nil then
         Damagelog.DiscordWebhookMode = config.DiscordWebhookMode
     else missing = 1 end
 

--- a/lua/damagelogs/config/config_loader.lua
+++ b/lua/damagelogs/config/config_loader.lua
@@ -1,10 +1,12 @@
 
-function Damagelog:saveConfig()
+function Damagelog:getConfig()
     local config = {}
     --Permissions
     config.Permissions = {}
     for user,right in pairs(Damagelog.User_rights) do    
-        config.Permissions[user] = {right,Damagelog.RDM_Manager_Rights[user]}
+        config.Permissions[user] = {}
+        config.Permissions[user].access_level = right
+        config.Permissions[user].can_access_rdm_manager = Damagelog.RDM_Manager_Rights[user]
     end
     config.Key = Damagelog.Key
     config.AbuseMessageMode = Damagelog.AbuseMessageMode
@@ -62,232 +64,117 @@ function Damagelog:saveConfig()
 
     config.PrivateMessagePrefix = Damagelog.PrivateMessagePrefix
     config.DiscordWebhookMode = Damagelog.DiscordWebhookMode
-    
+
+    return config
+end
+
+function Damagelog:saveConfig()
+    local config = Damagelog:getConfig()
     file.Write("damagelog/config.json",util.TableToJSON(config,true))
 end
 
 function Damagelog:loadConfig() --Returns 0 on good load, returns -1 on failure due to corrupted file, returns 1 if entries are missing. 
-    local missing = 0
     if not file.Exists("damagelog/config.json", "DATA") then --If no config exists save the default config (config.lua) and return as if we loaded one.
         Damagelog:saveConfig()
-        return 0
+        return
     end
-    local config = util.JSONToTable(file.Read("damagelog/config.json", "DATA"))
-    if not config then
-        ErrorNoHalt("Damagelogs: ERROR - Config Exists but is not valid JSON!")
-        return -1
+    local loaded_config = util.JSONToTable(file.Read("damagelog/config.json", "DATA"))
+    if not loaded_config then
+        ErrorNoHalt("Damagelogs: ERROR - Config Exists but is not valid JSON! Using default config.") 
+        return
     end
-
-    --Each part of the config is checked to see if it exists since if this is a update their config may not have new values. 
-    if config.Permissions then
-        Damagelog.User_rights = {}
-        Damagelog.RDM_Manager_Rights = {}
-        
-        for user,data in pairs(config.Permissions) do
-            Damagelog:AddUser(user,data[1],data[2])
+    local config = Damagelog:getConfig()    
+    
+    --Clear out current users and rights
+    Damagelog.User_rights = {}
+    Damagelog.RDM_Manager_Rights = {}
+    if loaded_config.Permissions != nil then  --Have to handle Perms a bit different then other config value since we don't want to use the defaults if someone has their own configured in the json config.
+        for user,data in pairs(loaded_config.Permissions) do
+            if data.access_level != nil and data.can_access_rdm_manager != nil then --Need to check for nils 
+                Damagelog:AddUser(user,data.access_level,data.can_access_rdm_manager)
+            end
         end
-    else missing = 1 end
-
-    if config.Key != nil then
-        Damagelog.Key = config.Key
-    else missing = 1 end
-
-    if config.AbuseMessageMode != nil then
-        Damagelog.AbuseMessageMode = config.AbuseMessageMode
-    else missing = 1 end
-
-    if config.RDM_Manager_Enabled != nil then
-        Damagelog.RDM_Manager_Enabled = config.RDM_Manager_Enabled
-    else missing = 1 end
-
-    if config.Commands then 
-        if config.Commands.RDM_Manager_Command != nil then
-            Damagelog.RDM_Manager_Command = config.Commands.RDM_Manager_Command
-        else missing = 1 end
-
-        if config.Commands.Respond_Command != nil then
-            Damagelog.Respond_Command = config.Commands.Respond_Command
-        else missing = 1 end
-    else missing = 1 end
+    else --If they don't have a valid Permission section in their JSON use the lua config / default.
+        for user,data in pairs(config.Permissions) do
+            Damagelog:AddUser(user,data.access_level,data.can_access_rdm_manager)
+        end
+    end
     
-    if config.Use_MySQL != nil then
-        Damagelog.Use_MySQL = Damagelog.Use_MySQL
-    else missing = 1 end
+    table.Merge(config,loaded_config) --Merge loaded json config into the lua config.
+
+    Damagelog.Key = config.Key
+    Damagelog.AbuseMessageMode = config.AbuseMessageMode
+    Damagelog.RDM_Manager_Enabled = config.RDM_Manager_Enabled
+    Damagelog.RDM_Manager_Command = config.Commands.RDM_Manager_Command
+    Damagelog.Respond_Command = config.Commands.Respond_Command
+    Damagelog.Use_MySQL = Damagelog.Use_MySQL
     
-    if config.Autoslay then
-        if config.Autoslay.ShowRemainingSlays != nil then
-            Damagelog.ShowRemainingSlays = config.Autoslay.ShowRemainingSlays
-        else missing = 1 end
+    Damagelog.ShowRemainingSlays = config.Autoslay.ShowRemainingSlays
 
-        if config.Autoslay.ULX_AutoslayMode != nil then
-            Damagelog.ULX_AutoslayMode = config.Autoslay.ULX_AutoslayMode
-        else missing = 1 end
+    Damagelog.ULX_AutoslayMode = config.Autoslay.ULX_AutoslayMode
+    Damagelog.ULX_Autoslay_ForceRole = config.Autoslay.ULX_Autoslay_ForceRole
+    Damagelog.ULX_Autoslay_ForceRole = config.Autoslay.Autoslay_CheckCustom
 
-        if config.Autoslay.ULX_Autoslay_ForceRole != nil then
-            Damagelog.ULX_Autoslay_ForceRole = config.Autoslay.ULX_Autoslay_ForceRole
-        else missing = 1 end
-       
-        if config.Autoslay.Autoslay_CheckCustom != nil then
-            Damagelog.ULX_Autoslay_ForceRole = config.Autoslay.Autoslay_CheckCustom
-        else missing = 1 end
+    Damagelog.Autoslay_DefaultReason = config.Autoslay.DefaultReason
+    Damagelog.Autoslay_DefaultReason1 = config.Autoslay.DefaultReason1
+    Damagelog.Autoslay_DefaultReason2 = config.Autoslay.DefaultReason2
+    Damagelog.Autoslay_DefaultReason3 = config.Autoslay.DefaultReason3
+    Damagelog.Autoslay_DefaultReason4 = config.Autoslay.DefaultReason4
+    Damagelog.Autoslay_DefaultReason5 = config.Autoslay.DefaultReason5
+    Damagelog.Autoslay_DefaultReason6 = config.Autoslay.DefaultReason6
+    Damagelog.Autoslay_DefaultReason7 = config.Autoslay.DefaultReason7
+    Damagelog.Autoslay_DefaultReason8 = config.Autoslay.DefaultReason8
+    Damagelog.Autoslay_DefaultReason9 = config.Autoslay.DefaultReason9
+    Damagelog.Autoslay_DefaultReason10 = config.Autoslay.DefaultReason10
+    Damagelog.Autoslay_DefaultReason11 = config.Autoslay.DefaultReason11
 
-        if config.Autoslay.DefaultReason != nil then
-            Damagelog.Autoslay_DefaultReason = config.Autoslay.DefaultReason
-        else missing = 1 end
+    Damagelog.AllowBanningThruManager = config.Ban.AllowBanningThruManager
 
-        if config.Autoslay.DefaultReason1 != nil then
-            Damagelog.Autoslay_DefaultReason1 = config.Autoslay.DefaultReason1
-        else missing = 1 end
+    Damagelog.Ban_DefaultReason1 = config.Ban.DefaultReason1
+    Damagelog.Ban_DefaultReason2 = config.Ban.DefaultReason2
+    Damagelog.Ban_DefaultReason3 = config.Ban.DefaultReason3
+    Damagelog.Ban_DefaultReason4 = config.Ban.DefaultReason4
+    Damagelog.Ban_DefaultReason5 = config.Ban.DefaultReason5
+    Damagelog.Ban_DefaultReason6 = config.Ban.DefaultReason6
+    Damagelog.Ban_DefaultReason7 = config.Ban.DefaultReason7
+    Damagelog.Ban_DefaultReason8 = config.Ban.DefaultReason8
+    Damagelog.Ban_DefaultReason9 = config.Ban.DefaultReason9
+    Damagelog.Ban_DefaultReason10 = config.Ban.DefaultReason10
+    Damagelog.Ban_DefaultReason11 = config.Ban.DefaultReason11
+    Damagelog.Ban_DefaultReason12 = config.Ban.DefaultReason12
 
-        if config.Autoslay.DefaultReason2 != nil then
-            Damagelog.Autoslay_DefaultReason2 = config.Autoslay.DefaultReason2
-        else missing = 1 end
+    Damagelog.NoStaffReports = config.Reports.NoStaffReports
 
-        if config.Autoslay.DefaultReason3 != nil then
-            Damagelog.Autoslay_DefaultReason3 = config.Autoslay.DefaultReason3
-        else missing = 1 end
+    Damagelog.MoreReportsPerRound = config.Reports.MoreReportsPerRound
 
-        if config.Autoslay.DefaultReason4 != nil then
-            Damagelog.Autoslay_DefaultReason4 = config.Autoslay.DefaultReason4
-        else missing = 1 end
+    Damagelog.ReportsBeforePlaying = config.Reports.ReportsBeforePlaying
 
-        if config.Autoslay.DefaultReason5 != nil then
-            Damagelog.Autoslay_DefaultReason5 = config.Autoslay.DefaultReason5
-        else missing = 1 end
+    Damagelog.LogDays = config.LogDays
 
-        if config.Autoslay.DefaultReason6 != nil then
-            Damagelog.Autoslay_DefaultReason6 = config.Autoslay.DefaultReason6
-        else missing = 1 end
+    Damagelog.HideDonateButton = config.HideDonateButton
 
-        if config.Autoslay.DefaultReason7 != nil then
-            Damagelog.Autoslay_DefaultReason7 = config.Autoslay.DefaultReason7
-        else missing = 1 end
+    Damagelog.UseWorkshop = config.UseWorkshop
 
-        if config.Autoslay.DefaultReason8 != nil then
-            Damagelog.Autoslay_DefaultReason8 = config.Autoslay.DefaultReason8
-        else missing = 1 end
+    Damagelog.ForcedLanguage = config.ForcedLanguage
 
-        if config.Autoslay.DefaultReason9 != nil then
-            Damagelog.Autoslay_DefaultReason9 = config.Autoslay.DefaultReason9
-        else missing = 1 end
+    Damagelog.PrivateMessagePrefix = config.PrivateMessagePrefix
 
-        if config.Autoslay.DefaultReason10 != nil then
-            Damagelog.Autoslay_DefaultReason10 = config.Autoslay.DefaultReason10
-        else missing = 1 end
-
-        if config.Autoslay.DefaultReason11 != nil then
-            Damagelog.Autoslay_DefaultReason11 = config.Autoslay.DefaultReason11
-        else missing = 1 end
-        
-        if config.Autoslay.DefaultReason12 != nil then
-            Damagelog.Autoslay_DefaultReason12 = config.Autoslay.DefaultReason12
-        else missing = 1 end
-    else missing = 1 end
-   
-    if config.Ban then
-        if config.Ban.AllowBanningThruManager != nil then
-            Damagelog.AllowBanningThruManager = config.Ban.AllowBanningThruManager
-        else missing = 1 end
-
-        if config.Ban.DefaultReason1 != nil then
-            Damagelog.Ban_DefaultReason1 = config.Ban.DefaultReason1
-        else missing = 1 end
-
-        if config.Ban.DefaultReason2 != nil then
-            Damagelog.Ban_DefaultReason2 = config.Ban.DefaultReason2
-        else missing = 1 end
-
-        if config.Ban.DefaultReason3 != nil then
-            Damagelog.Ban_DefaultReason3 = config.Ban.DefaultReason3
-        else missing = 1 end
-
-        if config.Ban.DefaultReason4 != nil then
-            Damagelog.Ban_DefaultReason4 = config.Ban.DefaultReason4
-        else missing = 1 end
-
-        if config.Ban.DefaultReason5 != nil then
-            Damagelog.Ban_DefaultReason5 = config.Ban.DefaultReason5
-        else missing = 1 end
-
-        if config.Ban.DefaultReason6 != nil then
-            Damagelog.Ban_DefaultReason6 = config.Ban.DefaultReason6
-        else missing = 1 end
-
-        if config.Ban.DefaultReason7 != nil then
-            Damagelog.Ban_DefaultReason7 = config.Ban.DefaultReason7
-        else missing = 1 end
-
-        if config.Ban.DefaultReason8 != nil then
-            Damagelog.Ban_DefaultReason8 = config.Ban.DefaultReason8
-        else missing = 1 end
-
-        if config.Ban.DefaultReason9 != nil then
-            Damagelog.Ban_DefaultReason9 = config.Ban.DefaultReason9
-        else missing = 1 end
-
-        if config.Ban.DefaultReason10 != nil then
-            Damagelog.Ban_DefaultReason10 = config.Ban.DefaultReason10
-        else missing = 1 end
-
-        if config.Ban.DefaultReason11 != nil then
-            Damagelog.Ban_DefaultReason11 = config.Ban.DefaultReason11
-        else missing = 1 end
-        
-        if config.Ban.DefaultReason12 != nil then
-            Damagelog.Ban_DefaultReason12 = config.Ban.DefaultReason12
-        else missing = 1 end
-    else missing = 1 end
+    Damagelog.DiscordWebhookMode = config.DiscordWebhookMode
     
-    if config.Reports then  
-        if config.Reports.NoStaffReports != nil then
-            Damagelog.NoStaffReports = config.Reports.NoStaffReports
-        else missing = 1 end
-        if config.Reports.MoreReportsPerRound != nil then
-            Damagelog.MoreReportsPerRound = config.Reports.MoreReportsPerRound
-        else missing = 1 end
-        if config.Reports.ReportsBeforePlaying != nil then
-            Damagelog.ReportsBeforePlaying = config.Reports.ReportsBeforePlaying
-        else missing = 1 end
-    else missing = 1 end    
-
-    if config.LogDays != nil then
-        Damagelog.LogDays = config.LogDays
-    else missing = 1 end
-
-    if config.HideDonateButton != nil then
-        Damagelog.HideDonateButton = config.HideDonateButton
-    else missing = 1 end
-
-    if config.UseWorkshop != nil then
-        Damagelog.UseWorkshop = config.UseWorkshop
-    else missing = 1 end
-
-    if config.ForcedLanguage != nil then
-        Damagelog.ForcedLanguage = config.ForcedLanguage
-    else missing = 1 end
-
-    if config.PrivateMessagePrefix != nil then
-        Damagelog.PrivateMessagePrefix = config.PrivateMessagePrefix
-    else missing = 1 end
-
-    if config.DiscordWebhookMode != nil then
-        Damagelog.DiscordWebhookMode = config.DiscordWebhookMode
-    else missing = 1 end
-
-    return missing
 end
 
 function Damagelog:loadMySQLConfig()
     if not file.Exists("damagelog/mysql.json", "DATA") then --If no mysql config exists save the default and return as if we loaded one.
         Damagelog:saveMySQLConfig()
-        return 0
+        return
     end
     local config = util.JSONToTable(file.Read("damagelog/mysql.json", "DATA"))
     if not config then
         ErrorNoHalt("Damagelogs: ERROR - MySQL Config Exists but is not valid JSON!")
-        return -1
+        return
     end
     Damagelog.MySQL_Informations = config
+
 end
 
 function Damagelog:saveMySQLConfig()

--- a/lua/damagelogs/config/config_loader.lua
+++ b/lua/damagelogs/config/config_loader.lua
@@ -188,7 +188,7 @@ function Damagelog:loadConfig() --Returns 0 on good load, returns -1 on failure 
         if config.Ban.AllowBanningThruManager != nil then
             Damagelog.AllowBanningThruManager = config.Ban.AllowBanningThruManager
         else missing = 1 end
-        print(config.Ban.DefaultReason1)
+
         if config.Ban.DefaultReason1 != nil then
             Damagelog.Ban_DefaultReason1 = config.Ban.DefaultReason1
         else missing = 1 end

--- a/lua/damagelogs/config/config_loader.lua
+++ b/lua/damagelogs/config/config_loader.lua
@@ -1,0 +1,296 @@
+
+function Damagelog:saveConfig()
+    local config = {}
+    --Permissions
+    config.Permissions = {}
+    for user,right in pairs(self.User_rights) do    
+        config.Permissions[user] = {right,self.RDM_Manager_Rights[user]}
+    end
+    config.Key = Damagelog.Key
+    config.AbuseMessageMode = Damagelog.AbuseMessageMode
+    config.RDM_Manager_Enabled = Damagelog.RDM_Manager_Enabled
+    --Commands
+    config.Commands = {}
+    config.Commands.RDM_Manager_Command = Damagelog.RDM_Manager_Command
+    config.Commands.Respond_Command = Damagelog.Respond_Command
+
+    config.Use_MySQL = Damagelog.Use_MySQL
+    --Autoslay stuff
+    config.Autoslay = {}
+    config.Autoslay.ShowRemainingSlays = Damagelog.ShowRemainingSlays
+    config.Autoslay.ULX_AutoslayMode = Damagelog.ULX_AutoslayMode
+    config.Autoslay.ULX_Autoslay_ForceRole = Damagelog.ULX_Autoslay_ForceRole
+    config.Autoslay.Autoslay_CheckCustom = Damagelog.Autoslay_CheckCustom
+    config.Autoslay.DefaultReason = Damagelog.Autoslay_DefaultReason
+    config.Autoslay.DefaultReason1 = Damagelog.Autoslay_DefaultReason1
+    config.Autoslay.DefaultReason2 = Damagelog.Autoslay_DefaultReason2
+    config.Autoslay.DefaultReason3 = Damagelog.Autoslay_DefaultReason3
+    config.Autoslay.DefaultReason4 = Damagelog.Autoslay_DefaultReason4
+    config.Autoslay.DefaultReason5 = Damagelog.Autoslay_DefaultReason5
+    config.Autoslay.DefaultReason6 = Damagelog.Autoslay_DefaultReason6
+    config.Autoslay.DefaultReason7 = Damagelog.Autoslay_DefaultReason7
+    config.Autoslay.DefaultReason8 = Damagelog.Autoslay_DefaultReason8
+    config.Autoslay.DefaultReason9 = Damagelog.Autoslay_DefaultReason9
+    config.Autoslay.DefaultReason10 = Damagelog.Autoslay_DefaultReason10
+    config.Autoslay.DefaultReason11 = Damagelog.Autoslay_DefaultReason11
+    config.Autoslay.DefaultReason12 = Damagelog.Autoslay_DefaultReason12
+    --Ban Stuff
+    config.Ban = {}
+    config.Ban.DefaultReason1 = Ban_DefaultReason1
+    config.Ban.DefaultReason2 = Ban_DefaultReason2
+    config.Ban.DefaultReason3 = Ban_DefaultReason3
+    config.Ban.DefaultReason4 = Ban_DefaultReason4
+    config.Ban.DefaultReason5 = Ban_DefaultReason5
+    config.Ban.DefaultReason6 = Ban_DefaultReason6
+    config.Ban.DefaultReason7 = Ban_DefaultReason7
+    config.Ban.DefaultReason8 = Ban_DefaultReason8
+    config.Ban.DefaultReason9 = Ban_DefaultReason9
+    config.Ban.DefaultReason10 = Ban_DefaultReason10
+    config.Ban.DefaultReason11 = Ban_DefaultReason11
+    config.Ban.DefaultReason12 = Ban_DefaultReason12
+    config.Ban.AllowBanningThruManager = Damagelog.AllowBanningThruManager
+    
+    config.LogDays = Damagelog.LogDays
+    config.HideDonateButton = Damagelog.HideDonateButton
+    config.UseWorkshop = Damagelog.UseWorkshop
+    config.ForcedLanguage = Damagelog.ForcedLanguage
+    --Report stuff
+    config.Reports = {}
+    config.Reports.NoStaffReports = Damagelog.NoStaffReports
+    config.Reports.MoreReportsPerRound = Damagelog.MoreReportsPerRound
+    config.Reports.ReportsBeforePlaying = Damagelog.ReportsBeforePlaying
+
+    config.PrivateMessagePrefix = Damagelog.PrivateMessagePrefix
+    config.DiscordWebhookMode = Damagelog.DiscordWebhookMode
+    
+    file.Write("damagelog/config.json",util.TableToJSON(config,true))
+end
+
+function Damagelog:loadConfig() --Returns 0 on good load, returns -1 on failure due to corrupted file, returns 1 if entries are missing. 
+    local missing = 0
+    if not file.Exists("damagelog/config.json", "DATA") then --If no config exists save the default config (config.lua) and return as if we loaded one.
+        Damagelog:saveConfig()
+        return 0
+    end
+    local config = util.JSONToTable(file.Read("damagelog/config.json", "DATA"))
+    if not config then
+        ErrorNoHalt("Damagelogs: ERROR - Config Exists but is not valid JSON!")
+        return -1
+    end
+
+    --Each part of the config is checked to see if it exists since if this is a update their config may not have new values. 
+    if config.Permissions then
+        Damagelog.User_rights = {}
+        Damagelog.RDM_Manager_Rights = {}
+        
+        for user,data in pairs(config.Permissions) do
+            Damagelog:AddUser(user,data[1],data[2])
+        end
+    else missing = 1 end
+
+    if not config.Key == nil then
+        Damagelog.Key = config.Key
+    else missing = 1 end
+
+    if not config.AbuseMessageMode == nil then
+        Damagelog.AbuseMessageMode = config.AbuseMessageMode
+    else missing = 1 end
+
+    if not config.RDM_Manager_Enabled == nil then
+        Damagelog.RDM_Manager_Enabled = config.RDM_Manager_Enabled
+    else missing = 1 end
+
+    if config.Commands then 
+        if not config.Commands.RDM_Manager_Command == nil then
+            Damagelog.RDM_Manager_Command = config.Commands.RDM_Manager_Command
+        else missing = 1 end
+
+        if not config.Commands.Respond_Command == nil then
+            Damagelog.Respond_Command = config.Commands.Respond_Command
+        else missing = 1 end
+    else missing = 1 end
+    
+    if not config.Use_MySQL == nil then
+        Damagelog.Use_MySQL = Damagelog.Use_MySQL
+    else missing = 1 end
+    
+    if config.Autoslay then
+        if not config.Autoslay.ShowRemainingSlays == nil then
+            Damagelog.ShowRemainingSlays = config.Autoslay.ShowRemainingSlays
+        else missing = 1 end
+
+        if not config.Autoslay.ULX_AutoslayMode == nil then
+            Damagelog.ULX_AutoslayMode = config.Autoslay.ULX_AutoslayMode
+        else missing = 1 end
+
+        if not config.Autoslay.ULX_Autoslay_ForceRole == nil then
+            Damagelog.ULX_Autoslay_ForceRole = config.Autoslau.ULX_Autoslay_ForceRole
+        else missing = 1 end
+       
+        if not config.Autoslay.Autoslay_CheckCustom == nil then
+            Damagelog.ULX_Autoslay_ForceRole = config.Autoslay.Autoslay_CheckCustom
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason == nil then
+            Damagelog.Autoslay_DefaultReason = config.Autoslay.DefaultReason
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason1 == nil then
+            Damagelog.Autoslay_DefaultReason1 = config.Autoslay.DefaultReason1
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason2 == nil then
+            Damagelog.Autoslay_DefaultReason2 = config.Autoslay.DefaultReason2
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason3 == nil then
+            Damagelog.Autoslay_DefaultReason3 = config.Autoslay.DefaultReason3
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason4 == nil then
+            Damagelog.Autoslay_DefaultReason4 = config.Autoslay.DefaultReason4
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason5 == nil then
+            Damagelog.Autoslay_DefaultReason5 = config.Autoslay.DefaultReason5
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason6 == nil then
+            Damagelog.Autoslay_DefaultReason6 = config.Autoslay.DefaultReason6
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason7 == nil then
+            Damagelog.Autoslay_DefaultReason7 = config.Autoslay.DefaultReason7
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason8 == nil then
+            Damagelog.Autoslay_DefaultReason8 = config.Autoslay.DefaultReason8
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason9 == nil then
+            Damagelog.Autoslay_DefaultReason9 = config.Autoslay.DefaultReason9
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason10 == nil then
+            Damagelog.Autoslay_DefaultReason10 = config.Autoslay.DefaultReason10
+        else missing = 1 end
+
+        if not config.Autoslay.DefaultReason11 == nil then
+            Damagelog.Autoslay_DefaultReason11 = config.Autoslay.DefaultReason11
+        else missing = 1 end
+        
+        if not config.Autoslay.DefaultReason12 == nil then
+            Damagelog.Autoslay_DefaultReason12 = config.Autoslay.DefaultReason12
+        else missing = 1 end
+    else missing = 1 end
+   
+    if config.Ban then
+        if not config.Ban.AllowBanningThruManager == nil then
+            Damagelog.AllowBanningThruManager = config.Ban.AllowBanningThruManager
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason1 == nil then
+            Damagelog.Ban_DefaultReason1 = config.Ban.DefaultReason1
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason2 == nil then
+            Damagelog.Ban_DefaultReason2 = config.Ban.DefaultReason2
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason3 == nil then
+            Damagelog.Ban_DefaultReason3 = config.Ban.DefaultReason3
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason4 == nil then
+            Damagelog.Ban_DefaultReason4 = config.Ban.DefaultReason4
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason5 == nil then
+            Damagelog.Ban_DefaultReason5 = config.Ban.DefaultReason5
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason6 == nil then
+            Damagelog.Ban_DefaultReason6 = config.Ban.DefaultReason6
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason7 == nil then
+            Damagelog.Ban_DefaultReason7 = config.Ban.DefaultReason7
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason8 == nil then
+            Damagelog.Ban_DefaultReason8 = config.Ban.DefaultReason8
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason9 == nil then
+            Damagelog.Ban_DefaultReason9 = config.Ban.DefaultReason9
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason10 == nil then
+            Damagelog.Ban_DefaultReason10 = config.Ban.DefaultReason10
+        else missing = 1 end
+
+        if not config.Ban.DefaultReason11 == nil then
+            Damagelog.Ban_DefaultReason11 = config.Ban.DefaultReason11
+        else missing = 1 end
+        
+        if not config.Ban.DefaultReason12 == nil then
+            Damagelog.Ban_DefaultReason12 = config.Ban.DefaultReason12
+        else missing = 1 end
+    else missing = 1 end
+    
+    if config.Reports then  
+        if not config.Reports.NoStaffReports == nil then
+            Damagelog.NoStaffReports = config.Reports.NoStaffReports
+        else missing = 1 end
+        if not config.Reports.MoreReportsPerRound == nil then
+            Damagelog.MoreReportsPerRound = config.Reports.MoreReportsPerRound
+        else missing = 1 end
+        if not config.Reports.ReportsBeforePlaying == nil then
+            Damagelog.ReportsBeforePlaying = config.Reports.ReportsBeforePlaying
+        else missing = 1 end
+    else missing = 1 end    
+
+    if not config.LogDays == nil then
+        Damagelog.LogDays = config.LogDays
+    else missing = 1 end
+
+    if not config.HideDonateButton == nil then
+        Damagelog.HideDonateButton = config.HideDonateButton
+    else missing = 1 end
+
+    if not config.UseWorkshop == nil then
+        Damagelog.UseWorkshop = config.UseWorkshop
+    else missing = 1 end
+
+    if not config.ForcedLanguage == nil then
+        Damagelog.ForcedLanguage = config.ForcedLanguage
+    else missing = 1 end
+
+    if not config.PrivateMessagePrefix == nil then
+        Damagelog.PrivateMessagePrefix = config.PrivateMessagePrefix
+    else missing = 1 end
+
+    if not config.DiscordWebhookMode == nil then
+        Damagelog.DiscordWebhookMode = config.DiscordWebhookMode
+    else missing = 1 end
+
+    return missing
+end
+
+function Damagelog:loadMySQLConfig()
+    if not file.Exists("damagelog/mysql.json", "DATA") then --If no mysql config exists save the default and return as if we loaded one.
+        Damagelog:saveMySQLConfig()
+        return 0
+    end
+    local config = util.JSONToTable(file.Read("damagelog/mysql.json", "DATA"))
+    if not config then
+        ErrorNoHalt("Damagelogs: ERROR - MySQL Config Exists but is not valid JSON!")
+        return -1
+    end
+    Damagelog.MySQL_Informations = config
+end
+
+function Damagelog:saveMySQLConfig()
+    file.Write("damagelog/mysql.json",util.TableToJSON(Damagelog.MySQL_Informations,true))
+end
+

--- a/lua/damagelogs/server/init.lua
+++ b/lua/damagelogs/server/init.lua
@@ -21,6 +21,11 @@ AddCSLuaFile("damagelogs/shared/autoslay.lua")
 include("damagelogs/shared/defines.lua")
 include("damagelogs/config/config.lua")
 include("damagelogs/config/mysqloo.lua")
+include("damagelogs/config/config_loader.lua")
+--Grab the configs as soon as possible since other code depends on it.
+Damagelog:loadMySQLConfig()
+Damagelog:loadConfig()
+
 include("damagelogs/server/sqlite.lua")
 include("damagelogs/shared/lang.lua")
 include("damagelogs/server/oldlogs.lua")

--- a/lua/damagelogs/server/init.lua
+++ b/lua/damagelogs/server/init.lua
@@ -24,9 +24,9 @@ include("damagelogs/config/mysqloo.lua")
 include("damagelogs/config/config_loader.lua")
 --Grab the configs as soon as possible since other code depends on it.
 Damagelog:loadMySQLConfig()
-if Damagelog:loadConfig() == 1 then
-    Damagelog:saveConfig()
-end
+Damagelog:loadConfig()
+Damagelog:saveConfig()
+
 
 include("damagelogs/server/sqlite.lua")
 include("damagelogs/shared/lang.lua")

--- a/lua/damagelogs/server/init.lua
+++ b/lua/damagelogs/server/init.lua
@@ -24,7 +24,9 @@ include("damagelogs/config/mysqloo.lua")
 include("damagelogs/config/config_loader.lua")
 --Grab the configs as soon as possible since other code depends on it.
 Damagelog:loadMySQLConfig()
-Damagelog:loadConfig()
+if Damagelog:loadConfig() == 1 then
+    Damagelog:saveConfig()
+end
 
 include("damagelogs/server/sqlite.lua")
 include("damagelogs/shared/lang.lua")


### PR DESCRIPTION
This pull request adds a new file in the config folder called `config_loader.lua` It has 4 functions two related to the `config.lua` and two related to `mysqloo.lua` 

The `config.lua` related function load and save the values present in `config.lua` from and to a file stored in `data/damagelog/config.json` 

The `mysqloo.lua` related functions do the same but for the settings in `mysqloo.lua`

Each entry is checked if it exists in the load function after the json is load as a table. This way if a new version of tttdamagelogs introduces a new config option everyone's configs are still valid. If any are missing it will then save the config which will save the defaults fron `config.lua` into the json file.

This is also a pathway for existing users to port their existing `config.lua` to the new json format. If the json files does not exist the load function will save the defaults, (values fron config.lua) and then return as if it had loaded properly.

This is an example of the json config file. (saved as a txt since I can't upload json to github on an PR) 
[config.txt](https://github.com/BadgerCode/tttdamagelogs/files/10541526/config.txt)


Annoying you can't sort keys when using util.TableToJSON. 

While the feature is complete this is a work in progress since I am not sure I am happy about how I have the json file setup. (Breaking things up into groups)

This is part of solving #60