### PR TITLE
fixed scripted entity print names not being used

### DIFF
--- a/lua/damagelogs/client/weapon_names.lua
+++ b/lua/damagelogs/client/weapon_names.lua
@@ -11,8 +11,8 @@ local function UpdateWeaponNames()
     table.Add(entsList, scripted_ents.GetList())
 
     for _, v in pairs(entsList) do
-        local printName = v.PrintName
-        local class = v.ClassName
+        local printName = v.PrintName or v.t and v.t.PrintName
+        local class = v.ClassName or v.t and v.t.ClassName
 
         if class and printName then
             local translated = LANG.TryTranslation(printName)


### PR DESCRIPTION
the weapons.GetList() function and the scripted_ents.GetList() function return a table in different formats

weapons.GetList() returns a table in a format like this:
```lua
{
	[1] = {
		ClassName = "weapon_example1",
		PrintName = "Example Name A",
	},
	[2] = {
		ClassName = "weapon_example2",
		PrintName = "Example Name B",
	},
}
```

scripted_ents.GetList() returns a table in a format like this:
```lua
{
	["sent_example1"] = {
		t = {
			ClassName = "sent_example1",
			PrintName = "Example Name A",
		},
	},
	["sent_example2"] = {
		t = {
			ClassName = "sent_example2",
			PrintName = "Example Name B",
		},
	},
}
```