### PR TITLE
Update CR4TTT RDM detection to support RDM-able teams other than traitors

### DIFF
--- a/lua/damagelogs/shared/events/kills.lua
+++ b/lua/damagelogs/shared/events/kills.lua
@@ -48,7 +48,10 @@ function event:DoPlayerDeath(ply, attacker, dmginfo)
 
         if attacker:GetRole() == ROLE_TRAITOR and (ply:GetRole() == ROLE_INNOCENT or ply:GetRole() == ROLE_DETECTIVE)
           or TTT2 and attacker:GetTeam() == TEAM_TRAITOR and not attacker:IsInTeam(ply)
-          or CR_VERSION and ((attacker:IsTraitorTeam() or attacker:IsMonsterTeam() or attacker:IsIndependentTeam()) and not attacker:IsSameTeam(ply)) then
+          -- Jesters are sometimes supposed to be killed, but when they aren't they generally have their own punishment mechanism so we don't need to mark this kill as RDM
+          -- Jesters also aren't supposed to be able to kill anyone, but there are some workshop weapons that bypass the damage blocking so we'll just allow their kills as non-RDM to be safe
+          -- Traitors, Monsters, and Indepedents are supposed to be killing everyone else so it's only RDM when they kill their own team (there are some edge cases with independents, but we won't get into that)
+          or CR_VERSION and (attacker:IsJesterTeam() or ply:IsJesterTeam() or ((attacker:IsTraitorTeam() or attacker:IsMonsterTeam() or attacker:IsIndependentTeam()) and not attacker:IsSameTeam(ply))) then
             net.WriteUInt(0, 1)
         else
             net.WriteUInt(1, 1)

--- a/lua/damagelogs/shared/events/kills.lua
+++ b/lua/damagelogs/shared/events/kills.lua
@@ -48,7 +48,7 @@ function event:DoPlayerDeath(ply, attacker, dmginfo)
 
         if attacker:GetRole() == ROLE_TRAITOR and (ply:GetRole() == ROLE_INNOCENT or ply:GetRole() == ROLE_DETECTIVE)
           or TTT2 and attacker:GetTeam() == TEAM_TRAITOR and not attacker:IsInTeam(ply)
-          or CR_VERSION and attacker:IsTraitorTeam() and not ply:IsTraitorTeam() then
+          or CR_VERSION and (attacker:IsInnocentTeam() or not attacker:IsSameTeam(ply)) then
             net.WriteUInt(0, 1)
         else
             net.WriteUInt(1, 1)

--- a/lua/damagelogs/shared/events/kills.lua
+++ b/lua/damagelogs/shared/events/kills.lua
@@ -48,7 +48,7 @@ function event:DoPlayerDeath(ply, attacker, dmginfo)
 
         if attacker:GetRole() == ROLE_TRAITOR and (ply:GetRole() == ROLE_INNOCENT or ply:GetRole() == ROLE_DETECTIVE)
           or TTT2 and attacker:GetTeam() == TEAM_TRAITOR and not attacker:IsInTeam(ply)
-          or CR_VERSION and (attacker:IsInnocentTeam() or not attacker:IsSameTeam(ply)) then
+          or CR_VERSION and ((attacker:IsTraitorTeam() or attacker:IsMonsterTeam() or attacker:IsIndependentTeam()) and not attacker:IsSameTeam(ply)) then
             net.WriteUInt(0, 1)
         else
             net.WriteUInt(1, 1)


### PR DESCRIPTION
In CR4TTT there are technically 5 "teams" 
1. Innocent (Includes Detectives)
2. Traitor
3. Monster
4. Independent
5. Jester

Following the base RDM logic:
1. Innocent kills are always RDM?
2. Traitors RDM when they kill their own team
3. Monsters RDM when they kill their own team
4. Independents generally don't have more than 1 member in a given round, but just in case... it's RDM when they kill their own team
5. Jesters can't do damage

So we can ignore Jesters entirely and check the team for traitors, monsters, and independents to cover them.
There are some edge cases like if a server decides to have have two different independent roles in a round at the same time then they aren't on the same "team" in reality... but this covers it well enough I think.