### PR TITLE
Mute self when answering reports

### DIFF
--- a/lua/damagelogs/client/rdm_manager.lua
+++ b/lua/damagelogs/client/rdm_manager.lua
@@ -55,6 +55,8 @@ local function BuildReportFrame(report)
             return
         end
 
+        RunConsoleCommand("-voicerecord")
+        
         net.Start("DL_Answering")
         net.SendToServer()
         ReportFrame = vgui.Create("DFrame")


### PR DESCRIPTION
When players are talking when the report window shows up, their mic will be stuck on while the window is active or they have to manually run the command, this simply stops the player's mic before answering.