### PR TITLE
Report reason/responses allow non-english characters and spaces

### DIFF
--- a/lua/damagelogs/client/rdm_manager.lua
+++ b/lua/damagelogs/client/rdm_manager.lua
@@ -122,7 +122,7 @@ local function BuildReportFrame(report)
 
             Button.DoClick = function()
                 local text = string.Trim(TextEntry:GetValue())
-                local size = #text:gsub("[^%g\128-\191\208-\210]+", ""):gsub("%s+", " ")
+                local size = #text
 
                 if size < 10 then
                     ShowError(TTTLogTranslate(GetDMGLogLang, "MinCharacters"))
@@ -430,7 +430,7 @@ function Damagelog:ReportWindow(found, deathLogs, previousReports, currentReport
     Submit:SetSize(370, 25)
 
     Submit.Think = function(self)
-        local characters = #Entry:GetText():gsub("[^%g\128-\191\208-\210]+", ""):gsub("%s+", " ")
+        local characters = #Entry:GetText()
         local disable = characters < 10 or not cur_selected
 
         if (select(2, Type:GetSelected()) ~= DAMAGELOG_REPORT_CHAT) then

--- a/lua/damagelogs/server/rdm_manager.lua
+++ b/lua/damagelogs/server/rdm_manager.lua
@@ -4,7 +4,7 @@ local hook_Call, hook_Add = hook.Call, hook.Add
 local util_JSONToTable, util_TableToJSON = util.JSONToTable, util.TableToJSON
 local player_GetHumans = player.GetHumans
 local table_Copy, table_Empty, table_insert, table_HasValue = table.Copy, table.Empty, table.insert, table.HasValue
-local string_Left, string_lower, string_gsub, string_format = string.Left, string.lower, string.gsub, string.format
+local string_Left, string_lower, string_format = string.Left, string.lower, string.format
 util.AddNetworkString("DL_AllowReport")
 util.AddNetworkString("DL_ReportPlayer")
 util.AddNetworkString("DL_UpdateReports")
@@ -301,7 +301,6 @@ function HandlePlayerReport(ply, attacker, message, reportType)
         reportType = DAMAGELOG_REPORT_STANDARD
     end
 
-    message = string_gsub(string_gsub(message, "[^%g\128-\191\194-\197\208-\210 ]+", ""), "%s+", " ")
     local adminOnline = AreAdminsOnline()
 
     -- TODO: Is this check correct? This means all the logic below only runs if the player isn't able to report anyway?
@@ -704,7 +703,6 @@ function HandleReportedPlayerAnswer(ply, previous, text, index)
         return
     end
 
-    text = string_gsub(string_gsub(text, "[^%g\128-\191\194-\197\208-\210 ]+", ""), "%s+", " ")
     tbl.response = text
 
     for _, v in ipairs(player_GetHumans()) do


### PR DESCRIPTION
This was preventing a number of other languages. See #95 and #112 

This was originally added to fix a crash, using invisible spaces- https://github.com/Tommy228/tttdamagelogs/issues/326
However, this no longer causes the game to crash.

As for spaces not counting to the minimum character count for a report reason/response, this seems a fairly pointless check.
If a player doesn't want to provide a valid report reason/response, they can just type in random letters or words.

