### PR TITLE
Utilize player.Iterator over player.GetAll

### DIFF
--- a/lua/damagelogs/client/rdm_manager.lua
+++ b/lua/damagelogs/client/rdm_manager.lua
@@ -367,7 +367,7 @@ function Damagelog:ReportWindow(found, deathLogs, previousReports, currentReport
         UserList:AddPlayer(killer, true)
     end
 
-    for _, v in ipairs(player.GetAll()) do
+    for _, v in player.Iterator() do
         if not (v == killer or v == client) then
             UserList:AddPlayer(v, false)
         end

--- a/lua/damagelogs/server/autoslay.lua
+++ b/lua/damagelogs/server/autoslay.lua
@@ -572,7 +572,7 @@ if Damagelog.ULX_Autoslay_ForceRole then
                     GAMEMODE.LastRole = {}
                 end
 
-                for _, v in ipairs(player.GetAll()) do
+                for _, v in player.Iterator() do
                     if IsValid(v) and (not v:IsSpec()) and not (v.AutoslaysLeft and tonumber(v.AutoslaysLeft) > 0) then
                         local r = GAMEMODE.LastRole[v:SteamID()] or v:GetRole() or ROLE_INNOCENT
                         table.insert(prev_roles[r], v)

--- a/lua/damagelogs/server/init.lua
+++ b/lua/damagelogs/server/init.lua
@@ -147,7 +147,7 @@ function Damagelog:TTTBeginRound()
         self.ShootTables[rounds + 1] = {}
         self.Roles[rounds + 1] = {}
 
-        for _, v in ipairs(player.GetAll()) do
+        for _, v in player.Iterator() do
             v:AddToDamagelogRoles(false)
         end
 


### PR DESCRIPTION
A micro-optimization that is more efficient and prevents the performance cost of using player.GetAll.

More info available on the GMod Wiki: https://wiki.facepunch.com/gmod/player.Iterator