### PR TITLE
Instead of asking if the direkt base is  weapon_tttbase we ask if *any* base is weapon_tttbase 

### DIFF
--- a/lua/damagelogs/server/damageinfos.lua
+++ b/lua/damagelogs/server/damageinfos.lua
@@ -56,14 +56,33 @@ function Damagelog:shootCallback(weapon)
     end
 end
 
+function IsBasedOn(gun, targetBase)
+    local current = gun:GetTable()
+    local visited = {}
+
+    while current and current.Base do
+        if current.Base == targetBase then
+            return true
+        end
+
+        -- Prevent infinite loops in broken base chains
+        if visited[current] then break end
+        visited[current] = true
+
+        current = weapons.GetStored(current.Base)
+    end
+
+    return false
+end
+
 hook.Add("EntityFireBullets", "BulletsCallback_DamagelogInfos", function(ent, data)
     if not IsValid(ent) or not ent:IsPlayer() then
         return
     end
 
     local wep = ent:GetActiveWeapon()
-
-    if IsValid(wep) and wep.Base == "weapon_tttbase" then
+    
+    if IsValid(wep) and IsBasedOn(wep, "weapon_tttbase") then
         Damagelog:shootCallback(wep)
     end
 end)

--- a/lua/damagelogs/server/damageinfos.lua
+++ b/lua/damagelogs/server/damageinfos.lua
@@ -66,8 +66,8 @@ function IsBasedOn(gun, targetBase)
         end
 
         -- Prevent infinite loops in broken base chains
-        if visited[current] then break end
-        visited[current] = true
+        if visited[current.Base] then break end
+        visited[current.Base] = true
 
         current = weapons.GetStored(current.Base)
     end


### PR DESCRIPTION
Previously we only asked "Is your base weapon_tttbase?" But that will break if people use bases between.
E.g. I use weapon -> maffinBase -> weapon_tttbase, my guns now never show up in shotlogs. This would happen for anyone with a similar setup.
This looks through the entire base tree if any at all is weapon_tttbase.