### PR TITLE
[feat] Add "Click here to join" to discord embed.

### DIFF
--- a/lua/damagelogs/server/discord.lua
+++ b/lua/damagelogs/server/discord.lua
@@ -6,6 +6,7 @@ local POST_MODES = {
 
 local HTTP = HTTP
 local url = CreateConVar("ttt_dmglogs_discordurl", "", FCVAR_PROTECTED + FCVAR_LUA_SERVER, "TTTDamagelogs - Discord Webhook URL")
+local steamconnectUrl = CreateConVar("ttt_dmglogs_steamconnect_url", "", FCVAR_PROTECTED + FCVAR_LUA_SERVER, "TTTDamagelogs - Steam connect URL template. Use %ip% and %port% as placeholders.")
 local disabled = Damagelog.DiscordWebhookMode == POST_MODES.DISABLED
 local emitOnlyWhenAdminsOffline = Damagelog.DiscordWebhookMode == POST_MODES.WHEN_ADMINS_OFFLINE
 local limit = 5
@@ -48,8 +49,6 @@ function Damagelog:DiscordMessage(discordUpdate)
     if disabled or (emitOnlyWhenAdminsOffline and discordUpdate.adminOnline) then
         return
     end
-
-    local steamconnectUrl = CreateConVar("ttt_dmglogs_steamconnect_url", "", FCVAR_PROTECTED + FCVAR_LUA_SERVER, "TTTDamagelogs - Steam connect URL template. Use %ip% and %port% as placeholders.")
 
     local serverField = nil
     local baseUrl = steamconnectUrl:GetString()

--- a/lua/damagelogs/server/discord.lua
+++ b/lua/damagelogs/server/discord.lua
@@ -49,7 +49,7 @@ function Damagelog:DiscordMessage(discordUpdate)
         return
     end
 
-    local steamconnectUrl = CreateConVar("ttt_dmglogs_steamconnect_url", "https://steamconnect.serpensin.com/?ip=%ip%&port=%port%", FCVAR_PROTECTED + FCVAR_LUA_SERVER, "TTTDamagelogs - Steam connect URL template. Use %ip% and %port% as placeholders.")
+    local steamconnectUrl = CreateConVar("ttt_dmglogs_steamconnect_url", "", FCVAR_PROTECTED + FCVAR_LUA_SERVER, "TTTDamagelogs - Steam connect URL template. Use %ip% and %port% as placeholders.")
 
     local serverField = nil
     local baseUrl = steamconnectUrl:GetString()

--- a/lua/damagelogs/server/discord.lua
+++ b/lua/damagelogs/server/discord.lua
@@ -49,28 +49,49 @@ function Damagelog:DiscordMessage(discordUpdate)
         return
     end
 
+    local steamconnectUrl = CreateConVar("ttt_dmglogs_steamconnect_url", "https://steamconnect.serpensin.com/?ip=%ip%&port=%port%", FCVAR_PROTECTED + FCVAR_LUA_SERVER, "TTTDamagelogs - Steam connect URL template. Use %ip% and %port% as placeholders.")
+
+    local serverField = nil
+    local baseUrl = steamconnectUrl:GetString()
+    if baseUrl ~= "" then
+        local serverIP = game.GetIPAddress() or ""
+        local ip, port = serverIP:match("([^:]+):(.+)")
+        if ip and port then
+            local joinLink = baseUrl:gsub("%%ip%%", ip):gsub("%%port%%", port)
+            serverField = {
+                name = "Server",
+                value = "[Click here to join](" .. joinLink .. ")",
+                inline = false
+            }
+        end
+    end
+
     local data = {
         title = TTTLogTranslate(nil, "webhook_header_report_submitted"):format(discordUpdate.reportId),
         description = TTTLogTranslate(nil, "webhook_ServerInfo"):format(game.GetMap(), discordUpdate.round),
         timestamp = os.date("!%Y-%m-%dT%H:%M:%S.000Z"),
-        fields = {
-            {
-                name = TTTLogTranslate(nil, "Victim") .. ":",
-                value = "[" .. discordUpdate.victim.nick:gsub("([%*_~<>\\@%]])", "\\%1") .. "](https://steamcommunity.com/profiles/" .. util.SteamIDTo64(discordUpdate.victim.steamID) .. ")\n" .. discordUpdate.victim.steamID,
-                inline = true
-            },
-            {
-                name = TTTLogTranslate(nil, "ReportedPlayer") .. ":",
-                value = "[" .. discordUpdate.attacker.nick:gsub("([%*_~<>\\@%]])", "\\%1") .. "](https://steamcommunity.com/profiles/" .. util.SteamIDTo64(discordUpdate.attacker.steamID) .. ")\n" .. discordUpdate.attacker.steamID,
-                inline = true
-            },
-            {
-                name = TTTLogTranslate(nil, "VictimsReport") .. ":",
-                value = discordUpdate.reportMessage:gsub("([%*_~<>\\@[])", "\\%1")
-            }
-        },
+        fields = {},
         color = 0xffff00
     }
+
+    if serverField then
+        table.insert(data.fields, serverField)
+    end
+
+    table.insert(data.fields, {
+        name = TTTLogTranslate(nil, "Victim") .. ":",
+        value = "[" .. discordUpdate.victim.nick:gsub("([%*_~<>\\@%]])", "\\%1") .. "](https://steamcommunity.com/profiles/" .. util.SteamIDTo64(discordUpdate.victim.steamID) .. ")\n" .. discordUpdate.victim.steamID,
+        inline = true
+    })
+    table.insert(data.fields, {
+        name = TTTLogTranslate(nil, "ReportedPlayer") .. ":",
+        value = "[" .. discordUpdate.attacker.nick:gsub("([%*_~<>\\@%]])", "\\%1") .. "](https://steamcommunity.com/profiles/" .. util.SteamIDTo64(discordUpdate.attacker.steamID) .. ")\n" .. discordUpdate.attacker.steamID,
+        inline = true
+    })
+    table.insert(data.fields, {
+        name = TTTLogTranslate(nil, "VictimsReport") .. ":",
+        value = discordUpdate.reportMessage:gsub("([%*_~<>\\@[])", "\\%1")
+    })
 
 
     if discordUpdate.responseMessage ~= nil then


### PR DESCRIPTION
I always found it a little bit annoying, that I couldn't just click a button to directly connect to the Server.
And Discord not embedding steam:// urls, didn't make it easier.
For that reason, I created a simple forwarder page, that takes IP and PORT as parameter and redirects you to steam://connect/.
I now added this function into the damage-logs, so I can directly join a server.
You can configure the url, that gets used in the server.cfg: `ttt_dmglogs_steamconnect_url "https://steamconnect.serpensin.com/?ip=%ip%&port=%port%"`.
[Here](https://gitlab.com/Serpensin/SteamConnect) you can find the repo of "SteamConnect".
You don't have to use my url and it's not even the default. You HAVE to set it, otherwise the field will not be in the embed.

I don't even know, if that is something useful for upstream. But maybe someone will find it as useful as myself.

<img width="456" height="298" alt="image" src="https://github.com/user-attachments/assets/6662c5f8-6516-42e7-a117-191e6ec423c7" />
